### PR TITLE
Fix C++11 headers could not be found

### DIFF
--- a/auto-complete-c-headers.el
+++ b/auto-complete-c-headers.el
@@ -32,7 +32,7 @@
 
 (defvar achead:include-patterns (list
                                  "\\.\\(h\\|hpp\\|hh\\)$" ; Standard header files
-                                 "/[a-zA-Z-]+$"           ; C++'s suffix-free include files (iostream, vector, ...)
+                                 "/[a-zA-Z-_]+$"           ; C++'s suffix-free include files (iostream, vector, unordered_map, ...)
                                  )
   "Regexp pattern list that limits the candidates. If a header
   file path matches a pattern in `achead:include-patterns', the
@@ -46,7 +46,7 @@ customized to your environment via commands like,
 
 or
 
-`gcc -xc++ -E-v -`
+`gcc -xc++ -E -v -`
 
 If you need to do more complicated things (like `pkg-config`),
 please consider to make your own function and set it to


### PR DESCRIPTION
- The C++11 standard library contains headers that have underscores. Add
  underscores to `achead:include-patterns'
- Add a space to separate -E and -v in the docstring of
  `achead:include-directories'
