### PR TITLE
Switch to cl-lib

### DIFF
--- a/auto-complete-c-headers.el
+++ b/auto-complete-c-headers.el
@@ -27,7 +27,7 @@
 ;;; Code:
 
 ;; For `remove-duplicates'
-(require 'cl)
+(require 'cl-lib)
 (require 'auto-complete)
 (require 'tramp)
 
@@ -71,7 +71,7 @@ please consider to make your own function and set it to
 (defun achead:get-include-directories-from-options (cmd-line-options)
   "Extract include directory names from command line options
   like (\"-I~/.local/include/\" \"-I~/src/include/\")."
-  (loop for option in cmd-line-options
+  (cl-loop for option in cmd-line-options
         when (let (case-fold-search)
                (string-match "^-I\\(.*\\)" option))
         collect (match-string 1 option)))
@@ -89,7 +89,7 @@ please consider to make your own function and set it to
 
 (defun achead:path-should-be-displayed (path)
   "Decide `path' should be displayed as a candidate."
-  (loop for include-pattern in achead:include-patterns
+  (cl-loop for include-pattern in achead:include-patterns
         when (string-match-p include-pattern path)
         return t))
 
@@ -99,11 +99,11 @@ enabled for directories returned by
 `achead:get-include-directories-function'."
   (let ((remote (and achead:inspect-remote-directories
                      (file-remote-p default-directory))))
-    (loop with dir-suffix = (or basedir "")
-          with include-base-dirs = (delete-duplicates (funcall achead:get-include-directories-function)
+    (cl-loop with dir-suffix = (or basedir "")
+          with include-base-dirs = (cl-delete-duplicates (funcall achead:get-include-directories-function)
                                                       :test 'string=)
           for include-base in include-base-dirs
-          append (loop with dir = (file-name-directory (concat (file-name-as-directory include-base)
+          append (cl-loop with dir = (file-name-directory (concat (file-name-as-directory include-base)
                                                                dir-suffix))
                        with files = (achead:file-list-for-directory (concat remote dir))
                        for file in files
@@ -138,7 +138,7 @@ just returns the path and content of the header file which
   "Candidate-collecting function for `auto-complete'."
   (ignore-errors
     (setq achead:ac-latest-results-alist (achead:get-include-file-candidates (file-name-directory ac-prefix)))
-    (loop for (candidate . path) in achead:ac-latest-results-alist
+    (cl-loop for (candidate . path) in achead:ac-latest-results-alist
           collect candidate)))
 
 (ac-define-source c-headers


### PR DESCRIPTION
The cl library is deprecated. This causes a warning every time auto-complete-c-headers is loaded, and might completely fail in the future. The replacement library is 'cl-lib' which provides the same functions with 'cl-' prepended.